### PR TITLE
Allow update-submission to take jsonobject as input parameter

### DIFF
--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -1124,7 +1124,7 @@ function Update-Submission
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $JsonPath,
 
-        [pscustomobject]$JsonObject,
+        [PSCustomObject]$JsonObject,
 
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $ZipPath,
@@ -1251,21 +1251,34 @@ function Update-Submission
         'NoStatus' = $NoStatus
     }
 
-    if ((-not [String]::IsNullOrWhiteSpace($JsonPath)) -and ($JsonObject -eq $null))
+    if (([String]::IsNullOrWhiteSpace($JsonPath)))
     {
-        Write-Log -Message "Reading in the submission content from: $JsonPath" -Level Verbose
-        if ($PSCmdlet.ShouldProcess($JsonPath, "Get-Content"))
+        if ($null -eq $JsonObject)
         {
-            $jsonSubmission = [string](Get-Content $JsonPath -Encoding UTF8) | ConvertFrom-Json
+            $message = "You need to specify either JsonPath or JsonObject"
+            Write-Log -Message $message -Level Error
+            throw $message
+        }
+        else
+        {
+            $jsonSubmission = $JsonObject
         }
     }
-    elseif (([String]::IsNullOrWhiteSpace($JsonPath)) -and ($JsonObject -ne $null)) {
-        $jsonSubmission = $jsonObject
-    }
-    else {
-        $message = "You should specify either JsonPath OR JsonObject.  Not both."
-        Write-Log -Message $message -Level Error
-        throw $message
+    else
+    {
+        if ($null -eq $JsonObject)
+        {
+            Write-Log -Message "Reading in the submission content from: $JsonPath" -Level Verbose
+            if ($PSCmdlet.ShouldProcess($JsonPath, "Get-Content"))
+            {
+                $jsonSubmission = [string](Get-Content $JsonPath -Encoding UTF8) | ConvertFrom-Json
+            }
+        }
+        else {
+            $message = "You can't specify both JsonPath and JsonObject"
+            Write-Log -Message $message -Level Error
+            throw $message
+        }
     }
 
     $product = Get-Product @commonParams -ProductId $ProductId

--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -1121,9 +1121,10 @@ function Update-Submission
 
         [string] $FlightId,
 
-        [Parameter(Mandatory)]
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $JsonPath,
+
+        [pscustomobject]$JsonObject,
 
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $ZipPath,
@@ -1250,10 +1251,21 @@ function Update-Submission
         'NoStatus' = $NoStatus
     }
 
-    Write-Log -Message "Reading in the submission content from: $JsonPath" -Level Verbose
-    if ($PSCmdlet.ShouldProcess($JsonPath, "Get-Content"))
+    if ((-not [String]::IsNullOrWhiteSpace($JsonPath)) -and ($JsonObject -eq $null))
     {
-        $jsonSubmission = [string](Get-Content $JsonPath -Encoding UTF8) | ConvertFrom-Json
+        Write-Log -Message "Reading in the submission content from: $JsonPath" -Level Verbose
+        if ($PSCmdlet.ShouldProcess($JsonPath, "Get-Content"))
+        {
+            $jsonSubmission = [string](Get-Content $JsonPath -Encoding UTF8) | ConvertFrom-Json
+        }
+    }
+    elseif (([String]::IsNullOrWhiteSpace($JsonPath)) -and ($JsonObject -ne $null)) {
+        $jsonSubmission = $jsonObject
+    }
+    else {
+        $message = "You should specify either JsonPath OR JsonObject.  Not both."
+        Write-Log -Message $message -Level Error
+        throw $message
     }
 
     $product = Get-Product @commonParams -ProductId $ProductId
@@ -1282,7 +1294,7 @@ function Update-Submission
             if ($jsonSubmission.appId -ne $appId)
             {
                 $output = @()
-                $output += "The AppId [$($jsonSubmission.appId))] in the submission content [$JsonPath] is not for the intended ProductId [$ProductId]."
+                $output += "The AppId [$($jsonSubmission.appId))] in the submission content is not for the intended ProductId [$ProductId]."
                 $output += "You either entered the wrong ProductId at the commandline, or you're referencing the wrong submission content to upload."
 
                 $newLineOutput = ($output -join [Environment]::NewLine)
@@ -1295,7 +1307,7 @@ function Update-Submission
     if ((-not [String]::IsNullOrWhiteSpace($jsonProductId)) -and ($ProductId -ne $jsonProductId))
     {
         $output = @()
-        $output += "The ProductId [$jsonProductId] in the submission content [$JsonPath] does not match the intended ProductId [$ProductId]."
+        $output += "The ProductId [$jsonProductId] in the submission content does not match the intended ProductId [$ProductId]."
         $output += "You either entered the wrong ProductId at the commandline, or you're referencing the wrong submission content to upload."
 
         $newLineOutput = ($output -join [Environment]::NewLine)

--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -1124,7 +1124,7 @@ function Update-Submission
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $JsonPath,
 
-        [PSCustomObject]$JsonObject,
+        [PSCustomObject] $JsonObject,
 
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $ZipPath,
@@ -1264,21 +1264,19 @@ function Update-Submission
             $jsonSubmission = $JsonObject
         }
     }
-    else
+    elseif ($null -eq $JsonObject)
     {
-        if ($null -eq $JsonObject)
+        Write-Log -Message "Reading in the submission content from: $JsonPath" -Level Verbose
+        if ($PSCmdlet.ShouldProcess($JsonPath, "Get-Content"))
         {
-            Write-Log -Message "Reading in the submission content from: $JsonPath" -Level Verbose
-            if ($PSCmdlet.ShouldProcess($JsonPath, "Get-Content"))
-            {
-                $jsonSubmission = [string](Get-Content $JsonPath -Encoding UTF8) | ConvertFrom-Json
-            }
-        }
-        else {
-            $message = "You can't specify both JsonPath and JsonObject"
-            Write-Log -Message $message -Level Error
-            throw $message
-        }
+            $jsonSubmission = [string](Get-Content $JsonPath -Encoding UTF8) | ConvertFrom-Json
+        }    
+    }
+    else 
+    {
+        $message = "You can't specify both JsonPath and JsonObject"
+        Write-Log -Message $message -Level Error
+        throw $message
     }
 
     $product = Get-Product @commonParams -ProductId $ProductId


### PR DESCRIPTION
update-Submission take JsonObject as an input. You have to specify either JsonPath or JsonObject, but not both. Meanwhile for the error message I just remove the variable reference to JsonPath. 