### PR TITLE
Duplicate images throws an exception.

### DIFF
--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -1281,8 +1281,8 @@ function Get-LocalizedMediaFile
     if ($image.Count -gt 1)
     {
         $output = "More then one version of [$Filename] has been found for this language. Please ensure only one copy of this media file exists within the language's sub-folders: [$($image.FullName -join ', ')]"
-        Write-Log -Message $output -Level Warning
-        #throw $output
+        Write-Log -Message $output -Level Error
+        throw $output
     }
 
     $fileFullPackagePath = Join-Path -Path $script:tempFolderPath -ChildPath $fileRelativePackagePath


### PR DESCRIPTION
In our media retrieval logic in PackageTool, we use the -Recurse switch when trying to find a specific file.  This means there is the possibility of retrieving more than one item.  Previously, we would warn the user when this case happened and we would continue with one of the items.  For StoreBroker v2, we will throw an exception because we shouldn't be making this decision for the user.