### PR TITLE
Allows a product to have no videos

### DIFF
--- a/StoreBroker/ConvertFrom-ExistingSubmission.ps1
+++ b/StoreBroker/ConvertFrom-ExistingSubmission.ps1
@@ -1578,7 +1578,10 @@ function ConvertFrom-Listing
         Add-ReleaseNotes -Xml $Xml -Listing $Listing
         $screenshots = Add-ScreenshotCaptions -Xml $xml -Images $images -LanguageCode $languageCode
         $additionalAssets = Add-AdditionalAssets -Xml $xml -Images $images -LanguageCode $languageCode
-        $trailerFiles = Add-Trailers -Xml $xml -Videos $videos -LanguageCode $languageCode
+        if($videos)
+        {
+            $trailerFiles = Add-Trailers -Xml $xml -Videos $videos -LanguageCode $languageCode
+        }
         Add-AppFeatures -Xml $Xml -Listing $Listing
         Add-RecommendedHardware -Xml $Xml -Listing $Listing
         Add-MinimumHardware -Xml $Xml -Listing $Listing


### PR DESCRIPTION
During development a title wont have trailers or other videos.  This change fixes an exception if there aren't any.