### PR TITLE
Grab appxbundle/appx manifests by direct path instead of recursive search

### DIFF
--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -2030,8 +2030,11 @@ function Read-AppxMetadata
     {
         $expandedAppxPath = Open-AppxContainer -AppxContainerPath $AppxPath
 
-        # Get AppxManifest.xml
-        $appxManifest = (Get-ChildItem -Recurse -Path $expandedAppxPath -Include 'AppxManifest.xml').FullName
+        # Get AppxManifest.xml under the appx root.
+        $appxManifest = Join-Path -Path $expandedAppxPath -ChildPath 'AppxManifest.xml' |
+            Get-Item -ErrorAction Ignore |
+            Select-Object -ExpandProperty FullName
+
         if ($null -eq $appxManifest)
         {
             Report-UnsupportedFile -Path $AppxPath
@@ -2251,8 +2254,11 @@ function Read-AppxBundleMetadata
     {
         $expandedContainerPath = Open-AppxContainer -AppxContainerPath $AppxbundlePath
 
-        # Get AppxBundleManifest.xml
-        $bundleManifestPath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include 'AppxBundleManifest.xml').FullName
+        # Get AppxBundleManifest.xml under the AppxMetadata folder.
+        $bundleManifestPath = Join-Path -Path $expandedContainerPath -ChildPath 'AppxMetadata\AppxBundleManifest.xml' |
+            Get-Item -ErrorAction Ignore |
+            Select-Object -ExpandProperty FullName
+
         if ($null -eq $bundleManifestPath)
         {
             Report-UnsupportedFile -Path $AppxbundlePath

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.19.1'
+    ModuleVersion = '1.19.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
Previously, we would recursively search under the bundle/appx root for the desired manifest. This caused problems for a customer whose packaging scripts had placed an unrelated manifest in a subdirectory of the appx.

In a valid bundle/appx, the manifests are expected to be at a specific relative path. This change updates PackageTool to acquire the manifests from the known path.