### PR TITLE
Grab appxbundle/appx manifests by direct path instead of recursive search

### DIFF
--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -1620,8 +1620,11 @@ function Read-AppxMetadata
     {
         $expandedAppxPath = Open-AppxContainer -AppxContainerPath $AppxPath
 
-        # Get AppxManifest.xml
-        $appxManifest = (Get-ChildItem -Recurse -Path $expandedAppxPath -Include 'AppxManifest.xml').FullName
+        # Get AppxManifest.xml under the appx root.
+        $appxManifest = Join-Path -Path $expandedAppxPath -ChildPath 'AppxManifest.xml' |
+            Get-Item -ErrorAction Ignore |
+            Select-Object -ExpandProperty FullName
+
         if ($null -eq $appxManifest)
         {
             Report-UnsupportedFile -Path $AppxPath
@@ -1841,8 +1844,11 @@ function Read-AppxBundleMetadata
     {
         $expandedContainerPath = Open-AppxContainer -AppxContainerPath $AppxbundlePath
 
-        # Get AppxBundleManifest.xml
-        $bundleManifestPath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include 'AppxBundleManifest.xml').FullName
+        # Get AppxBundleManifest.xml under the AppxMetadata folder.
+        $bundleManifestPath = Join-Path -Path $expandedContainerPath -ChildPath 'AppxMetadata\AppxBundleManifest.xml' |
+            Get-Item -ErrorAction Ignore |
+            Select-Object -ExpandProperty FullName
+
         if ($null -eq $bundleManifestPath)
         {
             Report-UnsupportedFile -Path $AppxbundlePath


### PR DESCRIPTION
Previously, we would recursively search under the bundle/appx root for the desired manifest. This caused problems for a customer whose packaging scripts had placed an unrelated manifest in a subdirectory of the appx.

In a valid bundle/appx, the manifests are expected to be at a specific relative path. This change updates PackageTool to acquire the manifests from the known path.